### PR TITLE
resolves 38: add git repo info to source command

### DIFF
--- a/commands/Source.js
+++ b/commands/Source.js
@@ -1,4 +1,8 @@
+const {EmbedBuilder, hyperlink} = require('discord.js');
+
 const Command = require('./Command.js');
+const Git = require('../services/Git.js');
+const Styles = require('../styles.json');
 
 /**
  * Returns GitHub repo for bot
@@ -9,7 +13,41 @@ class Source extends Command {
    * @param {BaseInteraction} interaction interaction executed
    */
   async execute(interaction) {
-    interaction.reply('https://github.com/Haxrox/Haxdroid');
+    await interaction.deferReply();
+
+    const git = new Git();
+
+    Promise.allSettled([
+      git.getBranch(),
+      git.getRevision(),
+      git.getRemote(),
+    ]).then((results) => {
+      const branch = results[0].value;
+      const revision = results[1].value;
+      const remote = results[2].value;
+
+      const embed = new EmbedBuilder()
+          .setTitle(`${interaction.client.user.username} Source`)
+          .setURL(remote)
+          .setThumbnail(interaction.client.user.avatarURL())
+          .addFields([
+            {
+              name: 'Branch',
+              value: hyperlink(branch, remote.concat('/tree/', branch)),
+            },
+            {
+              name: 'Revision',
+              value: hyperlink(revision, remote.concat('/commit/', revision)),
+            },
+          ])
+          .setColor(Styles.Colours.Theme)
+          .setTimestamp()
+          .setFooter({
+            text: `Requested by: ${interaction.user.username}`,
+            iconURL: interaction.user.avatarURL(),
+          });
+      interaction.editReply({embeds: [embed]});
+    });
   }
 }
 

--- a/commands/Source.js
+++ b/commands/Source.js
@@ -22,9 +22,12 @@ class Source extends Command {
       git.getRevision(),
       git.getRemote(),
     ]).then((results) => {
-      const branch = results[0].value;
-      const revision = results[1].value;
-      const remote = results[2].value;
+      const branch = results[0].status === 'fulfilled' ?
+        results[0].value : 'main';
+      const revision = results[1].status === 'fulfilled' ?
+        results[1].value : 'n/a';
+      const remote = results[2].status === 'fulfilled' ?
+        results[2].value : 'https://github.com/Haxrox/Haxdroid';
 
       const embed = new EmbedBuilder()
           .setTitle(`${interaction.client.user.username} Source`)
@@ -51,4 +54,7 @@ class Source extends Command {
   }
 }
 
-module.exports = new Source('Source', 'Gets the bot source code');
+module.exports = new Source(
+    'Source',
+    'Gets the bot Git repository information',
+);

--- a/services/Git.js
+++ b/services/Git.js
@@ -1,0 +1,39 @@
+const Process = require('./Process.js');
+
+/**
+ * Git service for fetching current branch + revision
+ */
+class Git {
+  /**
+   * Gets the current git branch
+   * @return {Promise<String>} current git branch
+   */
+  getBranch() {
+    return Process.exec('git status').then((result) => {
+      const regExp = new RegExp(/On branch (.*)/);
+      return result.stdout.match(regExp)[1].trim();
+    });
+  }
+
+  /**
+   * Gets the current git revision
+   * @return {Promise<String>} current git revision
+   */
+  getRevision() {
+    return Process.exec('git rev-parse HEAD').then((result) => {
+      return result.stdout.trim();
+    });
+  }
+
+  /**
+   * Gets the current git remote
+   * @return {Promise<String>} current git remote
+   */
+  getRemote() {
+    return Process.exec('git remote get-url $(git remote)').then((result) => {
+      return result.stdout.trim().slice(0, -4);
+    });
+  }
+}
+
+module.exports = Git;

--- a/services/Process.js
+++ b/services/Process.js
@@ -1,0 +1,11 @@
+const childProcess = require('child_process');
+const util = require('util');
+
+/**
+ * Promisify child process functions
+ */
+module.exports = {
+  exec: util.promisify(childProcess.exec),
+  spawn: util.promisify(childProcess.spawn),
+  execSync: util.promisify(childProcess.execSync),
+};


### PR DESCRIPTION
Uses `exec` to send commands to bash shell to fetch local git repo information