### PR TITLE
resolves #17: fix `.setURL` call

### DIFF
--- a/commands/Info.js
+++ b/commands/Info.js
@@ -28,7 +28,7 @@ class Info extends Command {
 
       embed.setColor(user.hexAccentColor || Styles.Colours.Theme)
           .setTitle(`${user.username} Info`)
-          .setURL(user === interaction.client.user && 'https://haxtech.web.app/projects/Haxdroid')
+          .setURL(user === interaction.client.user ? 'https://haxtech.web.app/projects/Haxdroid' : null)
           .setDescription(`**Profile:** ${user}`)
           .setThumbnail(user.avatarURL())
           .addFields(


### PR DESCRIPTION
When passing bot as a target, `.setURL` will be the Bot website. When not passing the bot, `.setURL` will be NULL, instead of false